### PR TITLE
refs qorelanguage/qore#386 fixed binding arbitary-precision numeric v…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ noinst_HEADERS = src/pgsql.h \
 EXTRA_DIST = COPYING.LGPL COPYING.MIT ChangeLog AUTHORS README \
 	RELEASE-NOTES \
 	src/ql_pgsql.qpp \
-	test/db-test.q \
+	test/pgsql.qtest \
 	test/sql-stmt.q \
 	qore-pgsql-module.spec
 

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -9,6 +9,7 @@ fixed a bug retrieving numeric values; values too large for a 64-bit integer wer
 minimum required Qore version is 0.8.12 to support the test script wth QUnit
 fixed a bug where interval values retrieved from the DB were justified to hours and minutes
 fixed a bug where CHAR values were returned with an invalid internal string size
+fixed a bug where arbitrary-precision numeric values bound to numeric columns were bound with an incorrect scale value causing the digigs behind the decimal place to be lost
 
 
 -----------

--- a/docs/mainpage.dox.tmpl
+++ b/docs/mainpage.dox.tmpl
@@ -207,6 +207,7 @@ hash: (1 member)
     - changed the minimum required Qore version to 0.8.12 to support the test script wth QUnit
     - fixed a bug where interval values retrieved from the DB were justified to hours and minutes
     - fixed a bug where \c CHAR values were returned with an invalid internal string size
+    - fixed a bug where arbitrary-precision numeric values bound to numeric columns were bound with an incorrect scale value causing the digigs behind the decimal place to be lost (<a href="https://github.com/qorelanguage/qore/issues/386">bug 386</a>)
 
     @subsection pgsql23 pgsql Driver Version 2.3
 

--- a/qore-pgsql-module.spec
+++ b/qore-pgsql-module.spec
@@ -93,7 +93,7 @@ This RPM provides API documentation, test and example programs
 
 %files doc
 %defattr(-,root,root,-)
-%doc docs/pgsql/html test/db-test.q test/sql-stmt.q
+%doc docs/pgsql/html test/pgsql.qtest test/sql-stmt.q
 
 %changelog
 * Mon Mar 24 2014 David Nichols <david@qore.org> 2.4

--- a/src/QorePGConnection.cpp
+++ b/src/QorePGConnection.cpp
@@ -4,7 +4,7 @@
 
   Qore Programming Language
 
-  Copyright 2003 - 2015 David Nichols
+  Copyright 2003 - 2016 David Nichols
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -178,6 +178,7 @@ qore_pg_numeric_out::qore_pg_numeric_out(const QoreNumberNode* n) : size(0) {
       di = str.size();
       while (i < di) {
          int nd = di - i;
+         dscale += nd;
          if (nd > 4)
             nd = 4;
          for (int j = 0; j < nd; ++j)

--- a/test/pgsql.qtest
+++ b/test/pgsql.qtest
@@ -127,7 +127,7 @@ class PgsqlTest inherits QUnit::Test {
 	    "bool_f"          : True,
 	    "float4_f"        : 21.3444,
 	    "float8_f"        : 49394.23423491,
-	    "number_f"        : pgsql_bind(PG_TYPE_NUMERIC, "7235634215.3250"),
+	    "number_f"        : 7235634215.3250n,
 	    "number2_f"       : 999999999999999999999999999999n,
 	    "number3_f"       : MAXINT,
 	    "number4_f"       : MAXINT.toNumber() + 1,
@@ -154,13 +154,13 @@ class PgsqlTest inherits QUnit::Test {
 
 	const OptionColumn = 20;
 
-	const MyOpts = (
+	const MyOpts = Opts + (
 	    "keep":  "k,keep",
 	    );
     }
 
     constructor() : Test("PgsqlTest", "1.0", \ARGV, MyOpts) {
-	*string cs = ENV.QORE_DB_CONNSTR ?? shift ARGV;
+	*string cs = ENV.QORE_DB_CONNSTR_PGSQL ?? shift ARGV;
 	if (!cs) {
 	    stderr.printf("QORE_DB_CONNSTR environment variable not set; cannot run tests\n");
 	    return;
@@ -176,7 +176,7 @@ class PgsqlTest inherits QUnit::Test {
 	createDataModel(db);
 
 	addTestCase("context test case", \contextTests());
-	addTestCase("transactio  test case", \transactionTests());
+	addTestCase("transaction test case", \transactionTests());
 	addTestCase("pgsql test case", \pgsqlTests());
 
 	set_return_value(main());


### PR DESCRIPTION
…alues; digits after the decimal point are no longer lost

renamed QUnit test script to qtest, added test for this bug
