### PR TITLE
Fix use of postgresql server headers when building with cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.0.0)
 project(qore-pgsql-module VERSION 2.4)
 
 option(enable-scu "build as a single compilation unit" ON)
+option(server-includes "build with pgsql server includes" OFF)
 
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
@@ -53,6 +54,10 @@ if(enable-scu)
 else(enable-scu)
     add_library(${module_name} SHARED ${CPP_SRC} ${QPP_SOURCES})
 endif(enable-scu)
+
+if(server-includes)
+    target_compile_definitions(${module_name} PUBLIC POSTGRESQL_SERVER_INCLUDES)
+endif(server-includes)
 
 qore_binary_module(${module_name} ${PROJECT_VERSION} ${PostgreSQL_LIBRARY} Threads::Threads)
 

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -1,8 +1,12 @@
 #ifndef _CONFIG_H
 #define _CONFIG_H
 
+/* The symbols in arpa/inet.h and netinet/in.h conflicts with the 
+   symbols that the postgresql server headers provide. */ 
+#ifndef POSTGRESQL_SERVER_INCLUDES
 #cmakedefine HAVE_ARPA_INET_H
 #cmakedefine HAVE_NETINET_IN_H
+#endif
 #cmakedefine HAVE_PQLIBVERSION
 #cmakedefine HAVE_GCC_VISIBILITY
 

--- a/src/QorePGConnection.h
+++ b/src/QorePGConnection.h
@@ -38,7 +38,7 @@
 
 #include <postgres_ext.h>         // for most basic types
 #ifdef POSTGRESQL_SERVER_INCLUDES
-#include <server/postgres.h>
+#include <postgres.h>
 #include <utils/nabstime.h>   // for abstime (AbsoluteTime), reltime (RelativeTime), tinterval (TimeInterval)
 #include <utils/date.h>       // for date (DateADT)
 #include <utils/timestamp.h>  // for interval (Interval*)


### PR DESCRIPTION
Add option that toggles use of postgresql server headers in cmake.
Make sure arpa/inet.h and netinet/in.h are not included when building
with postgresql server includes using cmake.
Fix inclusion of postgres.h when building with postgresql server includes.
