### PR TITLE
refs #3020 introduce exceptions arg alterr and alterr_diag to hold de…

### DIFF
--- a/docs/mainpage.dox.tmpl
+++ b/docs/mainpage.dox.tmpl
@@ -199,6 +199,8 @@ hash: (1 member)
     @subsection pgsql30 pgsql Driver Version 3.0
     <b>New Features and Bug Fixes</b>
     - updated to build with %Qore 0.9
+    - exceptions thrown by PostgreSQL module contains arg values with alterr and alterr_diag strings as described in
+      <a href="https://www.postgresql.org/docs/current/static/errcodes-appendix.html">PostgreSQL error codes</a>
 
     @subsection pgsql242 pgsql Driver Version 2.4.2
     <b>Bug Fixes</b>

--- a/src/QorePGConnection.cpp
+++ b/src/QorePGConnection.cpp
@@ -1901,7 +1901,8 @@ int QorePGConnection::get_server_version() const {
 #endif
 }
 
-const QoreHashNode* QorePGConnection::getExceptionArg(PGresult *res, ExceptionSink *xsink) {
+// static
+QoreHashNode* QorePGConnection::getExceptionArg(const PGresult *res, ExceptionSink *xsink) {
     QoreHashNode *arg = new QoreHashNode();
     if (res) {
         // The caller should not free the result directly (char* results).

--- a/src/QorePGConnection.h
+++ b/src/QorePGConnection.h
@@ -439,16 +439,7 @@ public:
         QoreStringNode *desc = new QoreStringNode(e);
         desc->chomp();
 
-        QoreHashNode* arg = new QoreHashNode();
-        if (res) {
-            char* sql_state = PQresultErrorField(res, PG_DIAG_SQLSTATE);
-            char* sql_diag = PQresultErrorField(res, PG_DIAG_MESSAGE_PRIMARY);
-            arg->setKeyValue("alterr", new QoreStringNode(sql_state), xsink);
-            arg->setKeyValue("alterr_diag", new QoreStringNode(sql_diag), xsink);
-        }
-        else {
-            arg->setKeyValue("alterr", new QoreStringNode(""), xsink);
-        }
+        const QoreHashNode* arg = getExceptionArg(res, xsink);
 
         xsink->raiseExceptionArg("DBI:PGSQL:ERROR", arg, desc);
         return -1;
@@ -465,6 +456,8 @@ public:
     DLLLOCAL bool wasInTransaction() const {
         return ds->activeTransaction();
     }
+
+    DLLLOCAL static const QoreHashNode* getExceptionArg(PGresult *res, ExceptionSink *xsink);
 };
 
 #ifdef HAVE_ARPA_INET_H

--- a/src/QorePGConnection.h
+++ b/src/QorePGConnection.h
@@ -457,7 +457,7 @@ public:
         return ds->activeTransaction();
     }
 
-    DLLLOCAL static const QoreHashNode* getExceptionArg(PGresult *res, ExceptionSink *xsink);
+    DLLLOCAL static QoreHashNode* getExceptionArg(const PGresult *res, ExceptionSink *xsink);
 };
 
 #ifdef HAVE_ARPA_INET_H

--- a/test/pgsql.qtest
+++ b/test/pgsql.qtest
@@ -166,7 +166,7 @@ class PgsqlTest inherits QUnit::Test {
     constructor() : Test("PgsqlTest", "1.0", \ARGV, MyOpts) {
         *string cs = ENV.QORE_DB_CONNSTR_PGSQL ?? shift ARGV;
         if (!cs) {
-            stderr.printf("QORE_DB_CONNSTR environment variable not set; cannot run tests\n");
+            stderr.printf("QORE_DB_CONNSTR_PGSQL environment variable not set; cannot run tests\n");
             return;
         }
         connstr = cs;
@@ -183,6 +183,7 @@ class PgsqlTest inherits QUnit::Test {
         addTestCase("transaction test case", \transactionTests());
         addTestCase("pgsql test case", \pgsqlTests());
         addTestCase("select row test", \selectRowTest());
+        addTestCase("alterr exceptions", \alterrExceptionTest());
 
         set_return_value(main());
     }
@@ -442,5 +443,22 @@ class PgsqlTest inherits QUnit::Test {
         db.vexec("insert into data_test values (" + vstr + ")", Args.values());
 
         assertThrows("DBI-SELECT-ROW-ERROR", \db.selectRow(), "select * from data_test");
+    }
+
+    private alterrExceptionTest() {
+        Datasource ds(connstr);
+        on_exit ds.rollback();
+
+        try {
+            ds.selectRow("select * from dalhlhwqsadcnfhe"); # table does not exist
+        }
+        catch (hash ex) {
+            assertEq(True, ex.hasKey("arg"));
+            hash arg = ex.arg;
+            assertEq(True, arg.hasKey("alterr"));
+            assertEq(True, arg.hasKey("alterr_diag"));
+            assertEq("42P01", arg.alterr);
+            assertEq(True, arg.alterr_diag =~ /dalhlhwqsadcnfhe/);
+        }
     }
 }


### PR DESCRIPTION
…tailed error code and description as it is described in:

https://www.postgresql.org/docs/current/static/errcodes-appendix.html

Example:

```
  err : "DBI:PGSQL:TRANSACTION-ERROR"
  desc : "connection to PostgreSQL database server lost while in a transaction; transaction has been lost"
  arg : hash: (2 members)
    alterr : "57P01"
    alterr_diag : "terminating connection due to administrator command"
```
